### PR TITLE
Revert "Ensure card only displays for coordinators of parent groups"

### DIFF
--- a/components/group_progress_card/group_progress_card.coffee
+++ b/components/group_progress_card/group_progress_card.coffee
@@ -9,7 +9,6 @@ angular.module('loomioApp').directive 'groupProgressCard', ->
 
     $scope.show = ->
       $scope.group.createdAt.isAfter(moment("2016-10-18")) &&
-      $scope.group.isParent() &&
       Session.user().isAdminOf($scope.group) &&
       !Session.user().hasExperienced("dismissProgressCard", $scope.group)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,11 +8,6 @@ module Plugins
 
         plugin.use_test_route(:setup_progress_card_coordinator) do
           GroupService.create(group: test_group, actor: patrick)
-          test_subgroup = Group.new(name: 'Johnny sub',
-                                    parent: test_group,
-                                    discussion_privacy_options: 'public_or_private',
-                                    group_privacy: 'closed')
-          GroupService.create(group: test_subgroup, actor: patrick)
           test_group.update_attribute(:enable_experiments, true)
           test_group.update_attribute(:description, 'Here is a group description')
           test_group.cover_photo = File.new("#{Rails.root}/spec/fixtures/images/strongbad.png")

--- a/test/group_progress_card_spec.coffee
+++ b/test/group_progress_card_spec.coffee
@@ -3,13 +3,11 @@ describe 'Group progress card', ->
   page = require '../../../angular/test/protractor/helpers/page_helper.coffee'
   staticPage = require '../../../angular/test/protractor/helpers/static_page_helper.coffee'
 
-  it 'is only visible to group coordinators of parent groups', ->
+  it 'is only visible to group coordinators', ->
     page.loadPath 'setup_progress_card_coordinator'
     page.expectText '.group-progress-card', 'ACTIVATE YOUR GROUP'
-    page.click '.subgroups-card__list-item-name a'
-    page.expectNoText '.group-page', 'ACTIVATE YOUR GROUP'
 
-  it 'is is not visible to non-coordinators', ->
+  it 'is only visible to group coordinators', ->
     page.loadPath 'setup_progress_card_member'
     page.expectNoText '.group-page', 'ACTIVATE YOUR GROUP'
 


### PR DESCRIPTION
Reverts loomio/loomio_onboarding#1